### PR TITLE
Use correct architectures in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library to control Grove Air Quality Sensor.
 paragraph=Arduino library to control Grove Air Quality Sensor.
 category=Sensors
 url=https://github.com/Seeed-Studio/Grove_Air_quality_Sensor
-architectures=*
+architectures=avr
 includes=AirQuality.h


### PR DESCRIPTION
The library uses AVR-specific code and will not compile for any other architecture. Therefore, the previous use of a wildcard architectures value was incorrect.

Use of a correct architectures value will cause the Arduino IDE to place the library's examples under **File > Examples > INCOMPATIBLE**. It will also give a helpful warning on compilation of the library:
```
WARNING: library Grove_Air_quality_Sensor-master claims to run on (avr) architecture(s) and may be incompatible with your current board which runs on (samd) architecture(s).
```
These will give the user valuable clues as to the cause of the somewhat obscure compilation errors.